### PR TITLE
Fix #158 customer page header link not clickable issue

### DIFF
--- a/static/less/root.less
+++ b/static/less/root.less
@@ -469,6 +469,11 @@ header {
   display: none;
 }
 
+div#page-header {
+  position: relative;
+  z-index: 100;
+}
+
 @import "ach-debits.less";
 @import "pricing.less";
 @import "customers.less";

--- a/templates/partials/page-header.html
+++ b/templates/partials/page-header.html
@@ -1,4 +1,4 @@
-<div class="bg-default hidden-responsive">
+<div id="page-header" class="bg-default hidden-responsive">
     <div class="container">
         <div class="row">
             <header class="site-header">


### PR DESCRIPTION
My solution here is to make the page header be `position: relative;` and `z-index: 100`. 
