### PR TITLE
Disable phone number linking on mobile safari

### DIFF
--- a/templates/partials/header.html
+++ b/templates/partials/header.html
@@ -2,6 +2,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=768, user-scalable=1">
+    <meta name="format-detection" content="telephone=no">
     <title>{{ page.metadata.title if page.metadata.title else name }}</title>
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <script type="text/javascript">var _pageStartTime=(new Date()).getTime()</script>


### PR DESCRIPTION
Trying to fix this:
![upload](https://cloud.githubusercontent.com/assets/91108/2988308/628cbd52-dc58-11e3-9343-6a95feea2423.png)
