### PR TITLE
fixed pricing typo

### DIFF
--- a/contents/pricing.md
+++ b/contents/pricing.md
@@ -45,7 +45,7 @@ features:
     cent: 25
     list:
       - name: Paying to your bank account
-        price: 0%
+        price: $0
       - name: Reversal
         price: $0
       - name: Failure


### PR DESCRIPTION
from "0%" to "$0"
